### PR TITLE
Updated readme, fixed the pushMany example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Sending messages in one push::
     $this->Apns->add('device token', 'message', $options, $sound);
     $this->Apns->add('antoher device token', 'message', $options, $sound);
     ...
-    $this->pushMany();
+    $this->Apns->pushMany();
     
 License
 -------


### PR DESCRIPTION
The pushMany is via $this->Apns->pushMany, the readme says $this->pushMany.

Amazing apn-php wrapper thanks!
