### PR TITLE
Fixed Component::startup method

### DIFF
--- a/Controller/Component/ApnsComponent.php
+++ b/Controller/Component/ApnsComponent.php
@@ -62,7 +62,7 @@ class ApnsComponent extends Component {
         return true;
     }
 
-    public function startup() {
+    public function startup(Controller $controller) {
         $this->__loadConfig();
         if(!file_exists($this->combined_cert_path)) {
 			throw new CakeException(__("Certification at $this->combined_cert_path does not exist."));


### PR DESCRIPTION
The component throws an exception 'Declaration of ApnsComponent::startup() should be compatible with Component::startup(Controller $controller)' in CakePHP 2.0.

Thanks!
